### PR TITLE
Set initial value for $TVL

### DIFF
--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -349,7 +349,7 @@ export default {
   data() {
     return {
       TVL: 12000, 
-      TVLinUsd: null,
+      TVLinUsd: 0,
       APY: "",
     };
   },


### PR DESCRIPTION
The initial value was set to null, which caused the UI to load only after API call to Coingecko  replied.  This caused the UI being "empty" for a few seconds or in worst case if the request failed it wouldn't load at all.

Fixed in this PR.