### PR TITLE
Add mailing list signup to landing page

### DIFF
--- a/src/components/Common/MailingListSubscribeForm.vue
+++ b/src/components/Common/MailingListSubscribeForm.vue
@@ -2,7 +2,7 @@
   <div>
     <div id="mc_embed_signup">
       <form
-        action="https://sharestake.us1.list-manage.com/subscribe/post?u=6cb6b636781c4fcc0b7cbccf1&amp;id=1e3ebab5ba"
+        action="https://sharedstake.us1.list-manage.com/subscribe/post?u=6cb6b636781c4fcc0b7cbccf1&amp;id=1e3ebab5ba"
         method="post"
         id="mc-embedded-subscribe-form"
         name="mc-embedded-subscribe-form"

--- a/src/components/Common/MailingListSubscribeForm.vue
+++ b/src/components/Common/MailingListSubscribeForm.vue
@@ -1,0 +1,105 @@
+<template>
+  <div>
+    <div id="mc_embed_signup">
+      <form
+        action="https://sharestake.us1.list-manage.com/subscribe/post?u=6cb6b636781c4fcc0b7cbccf1&amp;id=1e3ebab5ba"
+        method="post"
+        id="mc-embedded-subscribe-form"
+        name="mc-embedded-subscribe-form"
+        class="validate"
+        target="_blank"
+        novalidate
+      >
+        <div id="mc_embed_signup_scroll">
+          
+          <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+          <div style="position: absolute; left: -5000px" aria-hidden="true">
+            <input
+              type="text"
+              name="b_6cb6b636781c4fcc0b7cbccf1_1e3ebab5ba"
+              tabindex="-1"
+              value=""
+            />
+          </div>
+            <div class="subscribe">
+                <div class="input-container">
+                    <input
+                        type="email"
+                        value=""
+                        name="EMAIL"
+                        class="email"
+                        id="mce-EMAIL"
+                        placeholder="email address"
+                        required
+                    />
+                    <input
+                        type="submit"
+                        value="Subscribe"
+                        name="subscribe"
+                        id="mc-embedded-subscribe"
+                        class="submit-button"
+                    />
+                </div>
+            </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.subscribe {
+  font-size: 21px;
+  border: 2px solid #fff;
+  border-radius: 10px;
+  transition: transform 0.5s ease-out;
+  width: 65%;
+  margin: 0 auto;
+}
+
+.input-container {
+  display: flex;
+}
+
+input {   
+  padding: 0.5rem 1.5rem 0.5rem 1.5rem;
+  margin: 0;
+  text-decoration: none;
+  font-family: "Roboto";
+  color: #fff;
+  border: none;
+  background: none;
+  font-size: 21px;
+  width: 50%;
+}
+
+.submit-button {
+  cursor: pointer;
+}
+
+.email {
+  color: black;
+  background: #fff;
+  font-size: 21px;
+  border: 2px solid #fff;
+  border-style: solid none solid solid;
+  border-radius: 5px 0 0 5px;
+  text-align: center;
+  /* width: 142px; */
+  transition: transform 0.5s ease-out;
+}
+
+@media only screen and (max-width: 1270px) {
+  .subscribe {
+    width: 95%;
+  }
+
+  .email {
+    width: 60%
+  }
+
+  .submit-button {
+    width: 40%;
+  }
+}
+</style>

--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -352,12 +352,25 @@
         </a>
       </div>
     </div>
+    <div class=" flex_column" v-show="scrolled >= 1000">
+      <!-- <div class="exp background2"> -->
+        <div class="exp Information" v-show="scrolled >= 1500">
+          <div class="InfoHeader centertext" v-show="scrolled >= 1500">
+            Subscribe for newsletter
+          </div>
+          <div class="exp Info" v-show="scrolled >= 1500">      
+            <MailingListSubscribeForm />
+          </div>
+        </div>
+      <!-- </div> -->
+    </div>
     <div class="Container" v-show="scrolled <= 2900"></div>
   </div>
 </template>
 
 <script>
 import ImageVue from "../Handlers/ImageVue";
+import MailingListSubscribeForm from "../Common/MailingListSubscribeForm";
 import axios from "axios";
 import BN from "bignumber.js";
 import { timeout } from "@/utils/helpers";
@@ -365,7 +378,10 @@ import { SGT_uniswap, geyser_SGT_uniswap } from "@/contracts";
 import { priceInUsdAsync } from "@/utils/coingecko";
 
 export default {
-  components: { ImageVue },
+  components: { 
+    ImageVue,
+    MailingListSubscribeForm,
+  },
   props: ["scrolled", "windowWidth"],
   data() {
     return {

--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -356,7 +356,7 @@
       <!-- <div class="exp background2"> -->
         <div class="exp Information" v-show="scrolled >= 1500">
           <div class="InfoHeader centertext" v-show="scrolled >= 1500">
-            Subscribe for newsletter
+            Subscribe for updates from the team
           </div>
           <div class="exp Info" v-show="scrolled >= 1500">      
             <MailingListSubscribeForm />


### PR DESCRIPTION
Addresses https://github.com/SharedStake/SharedStake-ui/issues/65.

Texts and placeholder text can be changed. 
I stripped down some initial styles which were included in the html provided.

I also noticed that there's prolly typo in Mailchimp, since the url is https://**sharestake**.us1.list-manage.com as it should be share**d**stake. The return from the signup leads to nowhere (sharestake.org).

Please comment on the styles if you have any suggestions:
![image](https://user-images.githubusercontent.com/80589610/114443599-8add5600-9bd6-11eb-835c-4ec207b96624.png)
![image](https://user-images.githubusercontent.com/80589610/114443680-a2b4da00-9bd6-11eb-9d1a-b1f213c2d2cb.png)
