### PR TITLE
[Feat] Switch to gnosis onboard for gnosis safe integ

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+    "short_name": "SharedStake",
+    "name": "Shared Stake",
+    "description": "Sharedstake.org provides a defi compatible ETH2 staking derivative and managed validators",
+    "providedBy": {"name": "Shared stake", "url": "https://sharedstake.org"},
+    "iconPath": "./public/logo.svg",
+    "start_url": ".",
+    "display": "standalone",
+    "theme_color": "#000000",
+    "background_color": "#ffffff"
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@gnosis.pm/safe-apps-onboard": "0.3.0",
+    "@gnosis.pm/safe-apps-sdk": "2.3.0",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "bnc-notify": "^1.5.1",
-    "bnc-onboard": "^1.20.0",
+    "bnc-onboard": "1.25.0",
     "core-js": "^3.6.5",
     "sweetalert2": "^10.16.7",
     "three": "^0.126.1",

--- a/src/store/init/onboard.js
+++ b/src/store/init/onboard.js
@@ -1,5 +1,5 @@
 import Web3 from "web3";
-import Onboard from "bnc-onboard";
+import Onboard from '@gnosis.pm/safe-apps-onboard'
 import store from '../index'
 
 // const FORTMATIC_KEY = "Your Fortmatic key here"


### PR DESCRIPTION
Directions: 


hey chimera, thanks for pinging! I think its time for a SharedStake <> Gnosis Safe App!    

We have recently launched a new "Safe Provider" method which can be easily integrated into https://www.sharedstake.org/ and immediately turn it into a Gnosis Safe App for our app store interface. Best case this takes honestly 5 minutes, since you guys are using onboard.js.    

It means if you just replace onboard -> safe-onboard and add a manifest.json file, that should be all that's needed to into a safe app. Basically emulating our dev's 4 minute tutorial - https://www.youtube.com/watch?v=AfJCCVSQFT8&feature=emb_title    