### PR TITLE
Fix Documentation Link

### DIFF
--- a/src/Root.vue
+++ b/src/Root.vue
@@ -245,7 +245,7 @@
             >
             <span class="link footerLink">
               <a
-                href="https://docs.sharedstake.org/"
+                href="https://docs.sharedstake.finance/"
                 target="_blank"
                 rel="noopener noreferrer"
                 >Documentation


### PR DESCRIPTION
The documentation link in the footer was linking to the wrong page.