### PR TITLE
chore: migration from window.web3 to window.ethereum and a bug fix

### DIFF
--- a/src/components/Common/ApproveButton.vue
+++ b/src/components/Common/ApproveButton.vue
@@ -1,17 +1,21 @@
 <template>
   <span>
-    <dapp-tx-btn v-if="autoHide ? !enoughApproved : true" :click="genProps" :cb="wrappedCb">
+    <dapp-tx-btn
+      v-if="autoHide ? !enoughApproved : true"
+      :click="genProps"
+      :cb="wrappedCb"
+    >
       <span>Approve</span>
     </dapp-tx-btn>
   </span>
 </template>
-
 
 <script>
 import { mapGetters } from "vuex";
 import DappTxBtn from "../Common/DappTxBtn.vue";
 
 import BN from "bignumber.js";
+import { toWei } from "../../utils/common";
 BN.config({ ROUNDING_MODE: BN.ROUND_DOWN });
 BN.config({ EXPONENTIAL_AT: 100 });
 
@@ -21,11 +25,11 @@ export default {
   components: { DappTxBtn },
   data() {
     return {
-      userApproved: BN(0)
-    }
+      userApproved: BN(0),
+    };
   },
 
-  mounted: async function () {
+  mounted: async function() {
     await this.getApproved();
   },
 
@@ -34,19 +38,20 @@ export default {
       immediate: true,
       async handler() {
         await this.getApproved();
-      }
-    }
+      },
+    },
   },
 
   computed: {
     ...mapGetters({ userConnectedWalletAddress: "userAddress" }),
 
     enoughApproved() {
-      return this.userApproved.gte(this.amount)
+      return this.userApproved.gte(this.amount);
     },
 
     ethAmt() {
-      return window.web3.utils.toWei(this.amount?.toString(), "ether");
+      if (!this.amount) return 0;
+      return toWei(this.amount);
     },
   },
 
@@ -55,8 +60,8 @@ export default {
       return {
         abiCall: this.ABI_token.methods.approve,
         argsArr: [this.ABI_spender.options.address, this.ethAmt],
-        cb: this.wrappedCb
-      }
+        cb: this.wrappedCb,
+      };
     },
 
     async wrappedCb() {
@@ -73,6 +78,6 @@ export default {
         .call();
       this.userApproved = BN(userApproved);
     },
-  }
-}
+  },
+};
 </script>

--- a/src/components/Common/Chooser.vue
+++ b/src/components/Common/Chooser.vue
@@ -1,8 +1,13 @@
 <template>
   <div class="chooser">
     <div class="navbar">
-      <button v-for="(route, index) in this.routes" :key="route.id" class="switch"
-        :class="{ switch_active: activeRoute == index }" @click="onClick(index, route.cb)">
+      <button
+        v-for="(route, index) in this.routes"
+        :key="route.id"
+        class="switch"
+        :class="{ switch_active: activeRoute == index }"
+        @click="onClick(index, route.cb)"
+      >
         <span>{{ route.text }}</span>
       </button>
     </div>
@@ -11,14 +16,15 @@
 
 <script>
 import { mapGetters } from "vuex";
+import { toWei } from "../../utils/common";
 export default {
   name: "Chooser",
   props: ["routes", "currentActive"],
   components: {},
   data() {
     return {
-      activeRoute: parseInt(this.currentActive)
-    }
+      activeRoute: parseInt(this.currentActive),
+    };
   },
 
   computed: {
@@ -29,7 +35,7 @@ export default {
     },
 
     ethAmt() {
-      return window.web3.utils.toWei(this.amount?.toString(), "ether");
+      return toWei(this.amount);
     },
   },
   methods: {
@@ -40,9 +46,9 @@ export default {
     async asyncOnClick(index, cb) {
       this.activeRoute = index;
       return await cb(index, this.routes);
-    }
-  }
-}
+    },
+  },
+};
 </script>
 
 <style scoped>

--- a/src/components/Earn/Earn.vue
+++ b/src/components/Earn/Earn.vue
@@ -13,15 +13,16 @@
           </a> and proceed with extreme care. Deposits will be disabled until protocol upgrades land. But liquid vETH2 can be purchased via 1inch. 
         </div> -->
         <!-- <migrator /> -->
-        <div class="notification"> 
-          Checkout  
+        <div class="notification">
+          Checkout
           <a
             href="https://bunni.pro/stake"
             target="_blank"
             rel="noopener noreferrer"
           >
             bunni.pro</a
-          > for new farming pools!
+          >
+          for new farming pools!
         </div>
         <div class="notification">
           <!-- For new farming pools you can also use
@@ -51,7 +52,7 @@
         :chosen="chosen === pool.name"
         @toggle="chosen = chosen == pool.name ? null : pool.name"
       />
-      <div class="notification"> Old farms - please withdraw ASAP </div>
+      <div class="notification">Old farms - please withdraw ASAP</div>
       <geyser
         class="geyser geyser-old"
         v-for="pool in pools"
@@ -107,7 +108,8 @@ export default {
         active: true,
         tokenPerSgt: 1,
         oldPool: oldPools["geyser_SGT"],
-        link: "https://v2.info.uniswap.org/token/0x84810bcf08744d5862b8181f12d17bfd57d3b078", //for inactive pools => change this to uniswap
+        link:
+          "https://v2.info.uniswap.org/token/0x84810bcf08744d5862b8181f12d17bfd57d3b078", //for inactive pools => change this to uniswap
       },
       {
         name: "SGT - Eth",
@@ -120,7 +122,8 @@ export default {
         active: true,
         tokenPerSgt: 0,
         oldPool: oldPools["geyser_SGT_uniswap"],
-        link: "https://v2.info.uniswap.org/pair/0x3d07f6e1627da96b8836190de64c1aed70e3fc55", //for inactive pools => change this to uniswap
+        link:
+          "https://v2.info.uniswap.org/pair/0x3d07f6e1627da96b8836190de64c1aed70e3fc55", //for inactive pools => change this to uniswap
       },
       {
         name: "SGT - vEth2",
@@ -132,7 +135,8 @@ export default {
         external: false,
         active: true,
         tokenPerSgt: 0,
-        link: "https://v2.info.uniswap.org/pair/0xc794746df95c4b7043e8d6b521cfecab1b14c6ce", //for inactive pools => change this to uniswap
+        link:
+          "https://v2.info.uniswap.org/pair/0xc794746df95c4b7043e8d6b521cfecab1b14c6ce", //for inactive pools => change this to uniswap
       },
       {
         name: "vEth2",
@@ -160,7 +164,8 @@ export default {
         external: false,
         active: true,
         tokenPerSgt: 0,
-        link: "https://app.sushi.com/add/ETH/0x24C19F7101c1731b85F1127EaA0407732E36EcDD", //for inactive pools => change this to uniswap
+        link:
+          "https://app.sushi.com/add/ETH/0x24C19F7101c1731b85F1127EaA0407732E36EcDD", //for inactive pools => change this to uniswap
       },
       {
         name: "veSGT",
@@ -205,13 +210,12 @@ export default {
   computed: {
     ...mapGetters({ userAddress: "userAddress" }),
   },
-  mounted: async function () {
+  mounted: async function() {
     await this.mounted();
   },
   watch: {
     async userAddress(newVal) {
       if (newVal) await this.mounted;
-      console.log(newVal);
     },
   },
   methods: {
@@ -225,7 +229,10 @@ export default {
         const ethPerSgtFromUniswap = ethOnUniswapLP / sgtOnUniswapLP;
         //get vEth2 price from saddle pool
         let vEth2Pr = await vEth2Price();
-        vEth2Pr = vEth2Pr.dividedBy(1e18).toFixed(2).toString();
+        vEth2Pr = vEth2Pr
+          .dividedBy(1e18)
+          .toFixed(2)
+          .toString();
 
         this.pools[3].tokenPerSgt = ethPerSgtFromUniswap * vEth2Pr;
         this.newPools[0].tokenPerSgt = ethPerSgtFromUniswap; //saddle pool's LP token is simply 1 eth => possible improvement = get more accurate approach

--- a/src/components/Stake/Stake.vue
+++ b/src/components/Stake/Stake.vue
@@ -188,6 +188,7 @@ import StakeGauge from "./StakeGauge";
 import ApprovalButton from "../Common/ApproveButton.vue";
 import Chooser from "../Common/Chooser.vue";
 import DappTxBtn from "../Common/DappTxBtn.vue";
+import { toChecksumAddress } from "../../utils/common";
 
 // import { vEth2Price } from "@/utils/veth2.js";
 // import Swal from "sweetalert2";
@@ -354,7 +355,11 @@ export default {
       //balances
       try {
         let walletAddress = this.userAddress;
-        let amount = await window.web3.eth.getBalance(walletAddress);
+        let amount = await window.ethereum.request({
+          method: "eth_getBalance",
+          params: [walletAddress, "latest"],
+        });
+
         this.EthBal = BN(amount);
         let veth2 = await sgETH.methods.balanceOf(walletAddress).call();
         let wsgeth = await this.getUserWsgETHBalance();
@@ -377,9 +382,12 @@ export default {
         this.remaining = BN(remaining);
         let remainingByFee = await validator.methods.adminFeeTotal().call();
         this.remainingByFee = BN(remainingByFee).multipliedBy(320);
-        let contractBal = await window.web3.eth.getBalance(
-          window.web3.utils.toChecksumAddress(validator._address)
-        );
+
+        let contractBal = await window.ethereum.request({
+          method: "eth_getBalance",
+          params: [toChecksumAddress(validator._address), "latest"],
+        });
+
         this.contractBal = BN(contractBal);
         await this.getUserApprovedwsgEth();
         await this.getWsgETHRedemption();

--- a/src/components/Stake/Stake.vue
+++ b/src/components/Stake/Stake.vue
@@ -1,8 +1,13 @@
 <template>
   <div class="flex_column stake">
     <div class="staker">
-
-      <Chooser :routes="[{ text: 'Stake', cb: chooseCb}, { text: 'Unstake', cb: chooseCb }]" :currentActive="0"/>
+      <Chooser
+        :routes="[
+          { text: 'Stake', cb: chooseCb },
+          { text: 'Unstake', cb: chooseCb },
+        ]"
+        :currentActive="0"
+      />
 
       <div class="stakePage">
         <div class="sPElement input">
@@ -23,7 +28,9 @@
                 value=""
                 v-model="Damount"
               />
-              <div class="ant-col">{{ isDeposit ? " ETH" : (get_wsgETH ? 'wsgETH' : "sgETH") }}</div>
+              <div class="ant-col">
+                {{ isDeposit ? " ETH" : get_wsgETH ? "wsgETH" : "sgETH" }}
+              </div>
             </div>
             <div class="balance" id="balance" @click="onMAX">
               wallet: {{ balance }}
@@ -49,13 +56,17 @@
                 spellcheck="false"
                 :value="
                   isDeposit
-                    ? get_wsgETH ? ethTowsgETH : (Damount / (32)) * 32
-                    : get_wsgETH ? willGet : (Damount / 32) * (32 + adminFee)
+                    ? get_wsgETH
+                      ? ethTowsgETH
+                      : (Damount / 32) * 32
+                    : get_wsgETH
+                    ? willGet
+                    : (Damount / 32) * (32 + adminFee)
                 "
                 readonly
               />
               <div class="ant-col">
-                {{ isDeposit ? (get_wsgETH ? 'wsgETH' : "sgETH") : "ETH"}}
+                {{ isDeposit ? (get_wsgETH ? "wsgETH" : "sgETH") : "ETH" }}
               </div>
             </div>
             <div class="balance" id="balance" @click="onMAX">
@@ -67,46 +78,58 @@
 
         <div id="gas">
           <span id="gas">Gas</span>
-          <Chooser 
-            :routes="[{ 
-              text: gas.low.toFixed(0), 
-              cb: updateGasCb, 
-              }, {
-              text: gas.medium.toFixed(0), 
-              cb: updateGasCb,
-              }, {
-              text: gas.high.toFixed(0), 
-              cb: updateGasCb,
-            }]" 
+          <Chooser
+            :routes="[
+              {
+                text: gas.low.toFixed(0),
+                cb: updateGasCb,
+              },
+              {
+                text: gas.medium.toFixed(0),
+                cb: updateGasCb,
+              },
+              {
+                text: gas.high.toFixed(0),
+                cb: updateGasCb,
+              },
+            ]"
             :currentActive="0"
           />
-      </div>
-      <div class="navbar s-toggle">
-        <span id="gas">
+        </div>
+        <div class="navbar s-toggle">
+          <span id="gas">
             <input
               id="get-wsgETH"
               type="checkbox"
               name="get-wsgETH"
               v-model="get_wsgETH"
             />
-            <label for="get-wsgETH">{{ isDeposit ? 'Get' : 'Use' }} Wrapped SgETH (interest bearing)</label>
-        </span>
-      </div>
+            <label for="get-wsgETH"
+              >{{ isDeposit ? "Get" : "Use" }} Wrapped SgETH (interest
+              bearing)</label
+            >
+          </span>
+        </div>
 
-        <ApprovalButton 
-          v-if="!isDeposit && get_wsgETH && this.enoughFundsInExitPool && !this.enoughApproved"
+        <ApprovalButton
+          v-if="
+            !isDeposit &&
+              get_wsgETH &&
+              this.enoughFundsInExitPool &&
+              !this.enoughApproved
+          "
           :ABI_token="wsgETH"
           :ABI_spender="validator"
           :amount="this.Damount"
           :cb="this.getUserApprovedwsgEth"
           class="StakeButton"
         />
-        <dapp-tx-btn 
+        <dapp-tx-btn
           v-else
           class="StakeButton"
           :class="{
-              switch_active: buttonText == 'Unstake',
-            }"
+            switch_active: buttonText == 'Unstake',
+          }"
           :click="genSubmit"
         >
           <span>
@@ -114,7 +137,6 @@
           </span>
         </dapp-tx-btn>
 
-        
         <!-- <div class="notification" v-if="isDeposit">
           <a
             v-if="!enoughFundsInExitPool"
@@ -148,7 +170,6 @@
           >
         </div> -->
       </div>
-
     </div>
     <StakeGauge class="gauge" />
   </div>
@@ -177,7 +198,7 @@ export default {
     BNamount: BN(0),
     Damount: "",
     isDeposit: true,
-    get_wsgETH: true,
+    get_wsgETH: false,
     EthBal: BN(0),
     vEth2Bal: BN(0),
     userApprovedVEth2: BN(0),
@@ -199,9 +220,9 @@ export default {
     validator: validator,
     wsgETH: wsgETH,
     userWSGETHBal: BN(0),
-    wsgETHRedemptionPrice: BN(0)
+    wsgETHRedemptionPrice: BN(0),
   }),
-  mounted: async function () {
+  mounted: async function() {
     // this.gas = await getCurrentGasPrices();
     // this.chosenGas = this.gas.medium;
     this.loading = false;
@@ -219,29 +240,33 @@ export default {
   computed: {
     ...mapGetters({ userAddress: "userAddress" }),
     enoughFundsInExitPool() {
-      return (
-        this.BNamount.lte(this.contractBal)
-      );
+      return this.BNamount.lte(this.contractBal);
     },
     enoughApproved() {
-      return this.userApprovedwsgETH.gte(this.BNamount)
+      return this.userApprovedwsgETH.gte(this.BNamount);
     },
     willGet() {
       if (this.BNamount.eq(0)) return 0;
-      let c =  this.BNamount.multipliedBy(this.wsgETHRedemptionPrice.dividedBy(1e18)).dividedBy(1e18).toFixed(6);
+      let c = this.BNamount.multipliedBy(
+        this.wsgETHRedemptionPrice.dividedBy(1e18)
+      )
+        .dividedBy(1e18)
+        .toFixed(6);
       return c;
     },
     ethTowsgETH() {
       if (this.BNamount.eq(0)) return 0;
-      let c =  this.BNamount.multipliedBy(1e18).dividedBy(this.wsgETHRedemptionPrice).dividedBy(1e18).toFixed(6);
+      let c = this.BNamount.multipliedBy(1e18)
+        .dividedBy(this.wsgETHRedemptionPrice)
+        .dividedBy(1e18)
+        .toFixed(6);
       return c;
-    }
-
+    },
   },
   methods: {
     async chooseCb(index) {
       this.isDeposit = index > 0 ? false : true;
-      await this.mounted()
+      await this.mounted();
     },
     updateGasCb(index, routes) {
       this.updateGas(parseInt(routes[index].text));
@@ -287,21 +312,24 @@ export default {
       this.isDeposit = !this.isDeposit;
     },
     genSubmit() {
-      if (!(this.buttonText == "Stake" || this.buttonText == "Unstake")) return {};
+      if (!(this.buttonText == "Stake" || this.buttonText == "Unstake"))
+        return {};
 
       let fn = validator.methods,
         senderObj = {
-          gasPrice: BN(this.chosenGas).multipliedBy(1000000000).toString()
+          gasPrice: BN(this.chosenGas)
+            .multipliedBy(1000000000)
+            .toString(),
         },
         args = [];
       if (!this.isDeposit) {
         if (this.get_wsgETH) {
-            fn = fn.unstakeAndWithdraw;
-            args = [this.BNamount.toString(), this.userAddress];
-          } else {
-            fn = fn.withdraw;
-            args = [this.BNamount.toString()];
-          }
+          fn = fn.unstakeAndWithdraw;
+          args = [this.BNamount.toString(), this.userAddress];
+        } else {
+          fn = fn.withdraw;
+          args = [this.BNamount.toString()];
+        }
       } else {
         senderObj.value = this.BNamount.toString();
         senderObj.gas = 200000;
@@ -318,8 +346,8 @@ export default {
         cb: async () => {
           this.loading = false;
           await this.mounted();
-        }
-      }
+        },
+      };
     },
 
     async mounted() {
@@ -331,14 +359,19 @@ export default {
         let veth2 = await sgETH.methods.balanceOf(walletAddress).call();
         let wsgeth = await this.getUserWsgETHBalance();
         this.vEth2Bal = BN(veth2);
-        let _parse = (n) => BN(n).dividedBy(1e18).toFixed(6);
+        let _parse = (n) =>
+          BN(n)
+            .dividedBy(1e18)
+            .toFixed(6);
 
         if (this.isDeposit) {
           this.balance = _parse(amount);
           this.otherBalance = this.get_wsgETH ? _parse(wsgeth) : _parse(veth2);
         } else {
           this.balance = this.get_wsgETH ? _parse(wsgeth) : _parse(veth2);
-          this.otherBalance = BN(amount).dividedBy(1e18).toFixed(6);
+          this.otherBalance = BN(amount)
+            .dividedBy(1e18)
+            .toFixed(6);
         }
         let remaining = await validator.methods.remainingSpaceInEpoch().call();
         this.remaining = BN(remaining);
@@ -388,7 +421,9 @@ export default {
         ? this.EthBal.minus(BN(this.chosenGas * 200000 * 1000000000)).gte(
             this.BNamount
           )
-        : this.get_wsgETH ? BN(this.userWSGETHBal).gte(this.BNamount) : this.vEth2Bal.gte(this.BNamount);
+        : this.get_wsgETH
+        ? BN(this.userWSGETHBal).gte(this.BNamount)
+        : this.vEth2Bal.gte(this.BNamount);
       if (!this.validInput) {
         this.buttonText = "Insufficient balance";
         return;
@@ -403,13 +438,9 @@ export default {
       }
     },
     async getUserWsgETHBalance() {
-      let bal = await wsgETH.methods
-        .balanceOf(
-          this.userAddress
-        )
-        .call();
-        this.userWSGETHBal = bal;
-        return bal;
+      let bal = await wsgETH.methods.balanceOf(this.userAddress).call();
+      this.userWSGETHBal = bal;
+      return bal;
     },
     async getWsgETHRedemption() {
       let vp = await wsgETH.methods.pricePerShare().call();
@@ -417,16 +448,13 @@ export default {
     },
     async getUserApprovedwsgEth() {
       let userApproved = await wsgETH.methods
-        .allowance(
-          this.userAddress,
-          validator.options.address
-        )
+        .allowance(this.userAddress, validator.options.address)
         .call();
       this.userApprovedwsgETH = BN(userApproved);
     },
   },
   watch: {
-    Damount: function (newValue, oldVal) {
+    Damount: function(newValue, oldVal) {
       if (newValue.length > 40) {
         this.Damount = oldVal;
         this.amountCheck();
@@ -463,7 +491,7 @@ export default {
     get_wsgETH: async function() {
       await this.mounted();
     },
-    isDeposit: function (val) {
+    isDeposit: function(val) {
       let balance = val ? this.EthBal : this.vEth2Bal;
       this.balance = balance.dividedBy(1e18).toFixed(6);
       let otherBalance = val ? this.vEth2Bal : this.EthBal;
@@ -471,7 +499,7 @@ export default {
       this.Damount = "";
       this.buttonText = "Enter an amount";
     },
-    validInput: function (val) {
+    validInput: function(val) {
       if (!val) {
         if (this.Damount == 0) {
           this.buttonText = "Enter an amount";

--- a/src/components/Stake/Unwrap.vue
+++ b/src/components/Stake/Unwrap.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="w-5/6 max-w-2xl pt-40 mx-auto">
-    <section class="relative gap-4 p-6 my-10 text-white bg-gray-800 shadow-md rounded-xl">
+    <section
+      class="relative gap-4 p-6 my-10 text-white bg-gray-800 shadow-md rounded-xl"
+    >
       <span
-        class="absolute p-1 px-3 text-sm font-bold text-gray-200 transform -translate-x-1/2 rounded-full opacity-95 left-1/2 -top-3 bg-brand-primary">Beta</span>
+        class="absolute p-1 px-3 text-sm font-bold text-gray-200 transform -translate-x-1/2 rounded-full opacity-95 left-1/2 -top-3 bg-brand-primary"
+        >Beta</span
+      >
 
-      <Chooser :routes="this.routes" :currentActive="this.title == 'Wrap' ? 0 : 1" />
+      <Chooser
+        :routes="this.routes"
+        :currentActive="this.title == 'Wrap' ? 0 : 1"
+      />
 
       <div class="flex flex-col items-center justify-center">
         <header class="pb-3 my-4 text-center">
@@ -17,24 +24,36 @@
         </header>
 
         <!-- Progress - show completed steps status -->
-        <div class="pb-3 mb-6 border-b border-gray-700" v-if="userWalletIsConnected">
+        <div
+          class="pb-3 mb-6 border-b border-gray-700"
+          v-if="userWalletIsConnected"
+        >
           <aside class="flex flex-wrap justify-center gap-3 md:gap-6">
-            <Step :title="`${title} ${inputTokenName}`" :completed="this.completed" step="1" />
+            <Step
+              :title="`${title} ${inputTokenName}`"
+              :completed="this.completed"
+              step="1"
+            />
           </aside>
         </div>
 
         <label v-if="this.depositStage">
           <p class="text-sm font-semibold text-gray-300 mb-0.5">
-            How much {{inputTokenName}} would you unwrap for {{ outputTokenName }}?
+            How much {{ inputTokenName }} would you unwrap for
+            {{ outputTokenName }}?
           </p>
-          <div class="relative flex items-center gap-1 p-2 text-xl border border-gray-200 rounded-xl">
-            <input :value="amount" class="max-w-xs ml-2 text-white bg-transparent border-none outline-none" 
+          <div
+            class="relative flex items-center gap-1 p-2 text-xl border border-gray-200 rounded-xl"
+          >
+            <input
+              :value="amount"
+              class="max-w-xs ml-2 text-white bg-transparent border-none outline-none"
               :placeholder="
                 this.userTokenBalance
                   .div(10 ** 18)
                   .decimalPlaces(6)
                   .toString()
-              " 
+              "
               @input="
                 amount = isNaN(parseFloat($event.target.value))
                   ? 0
@@ -42,15 +61,19 @@
               "
             />
             <span class="text-sm">
-              {{inputTokenName}}
+              {{ inputTokenName }}
             </span>
-            <button @click="handleFillMaxAmount" v-if="true"
-              class=" px-1 py-0.5 text-xs font-semibold bg-white rounded text-brand-primary">
+            <button
+              @click="handleFillMaxAmount"
+              v-if="true"
+              class=" px-1 py-0.5 text-xs font-semibold bg-white rounded text-brand-primary"
+            >
               max
             </button>
           </div>
           <p class="text-sm font-semibold text-gray-300 mb-0.5">
-            Current {{outputTokenName}} Balance: {{ parseBN(userOutputTokenBalance) }} 
+            Current {{ outputTokenName }} Balance:
+            {{ parseBN(userOutputTokenBalance) }}
           </p>
         </label>
 
@@ -63,12 +86,18 @@
           <ConnectButton v-else-if="!userConnectedWalletAddress" />
 
           <template v-else>
-            <p v-if="!userHasTokenBalance" class="mt-2 text-sm font-semibold text-gray-200">
-              You need to have {{inputTokenName}} tokens in your wallet in order to continue
-              {{ outputTokenName }}.
+            <p
+              v-if="!userHasTokenBalance"
+              class="mt-2 text-sm font-semibold text-gray-200"
+            >
+              You need to have {{ inputTokenName }} tokens in your wallet in
+              order to continue {{ outputTokenName }}.
             </p>
 
-            <dapp-tx-btn v-else-if="stage == 'depositStage'" :click="handleClick">
+            <dapp-tx-btn
+              v-else-if="stage == 'depositStage'"
+              :click="handleClick"
+            >
               <span> {{ this.title }}</span>
             </dapp-tx-btn>
           </template>
@@ -88,6 +117,7 @@ import Chooser from "../Common/Chooser.vue";
 import DappTxBtn from "../Common/DappTxBtn.vue";
 
 import ImageVue from "../Handlers/ImageVue.vue";
+import { toWei } from "../../utils/common";
 
 // Max unit is the maximum value that can be represented in Solidity
 // const MAX_UNIT = 2 ** 256 - 1;
@@ -102,7 +132,7 @@ export default {
     ConnectButton,
     Step,
     Chooser,
-    DappTxBtn
+    DappTxBtn,
   },
 
   data() {
@@ -114,14 +144,17 @@ export default {
       error: false,
       dev: true, // change to true for log
       completed: false, // Full process completed (in one session)
-      routes: [{ text: 'Wrap', cb: this.routeClickCb }, { text: 'Unwrap', cb: this.routeClickCb }],
+      routes: [
+        { text: "Wrap", cb: this.routeClickCb },
+        { text: "Unwrap", cb: this.routeClickCb },
+      ],
       wsgETH: wsgETH,
       sgETH: sgETH,
       ABI: wsgETH,
       title: "Unwrap",
       descr: "Unwrap wsgETH to sgETH",
       outputTokenName: "sgETH",
-      inputTokenName: "wsgETH"
+      inputTokenName: "wsgETH",
     };
   },
 
@@ -159,25 +192,23 @@ export default {
       return (
         this.amount &&
         this.amount <
-        this.userTokenBalance
-          .div(10 ** 18)
-          .decimalPlaces(6)
-          .toString()
+          this.userTokenBalance
+            .div(10 ** 18)
+            .decimalPlaces(6)
+            .toString()
       );
     },
 
     depositStage() {
-      return (
-        this.userWalletIsConnected &&
-        this.userCanRequestWithdrawal
-      );
+      return this.userWalletIsConnected && this.userCanRequestWithdrawal;
     },
 
     completedStepsCount() {
       return this.depositStage + 1;
     },
 
-    stage() { // need to improve this. 
+    stage() {
+      // need to improve this.
       if (!this.userWalletIsConnected) return false;
       return "depositStage";
     },
@@ -191,17 +222,22 @@ export default {
     handleClick() {
       return {
         abiCall: this.wsgETH.methods.redeem,
-        argsArr: [window.web3.utils.toWei(this.amount, "ether"), this.userConnectedWalletAddress, this.userConnectedWalletAddress],
+        argsArr: [
+          toWei(this.amount),
+          this.userConnectedWalletAddress,
+          this.userConnectedWalletAddress,
+        ],
         cb: async () => {
           await this.refreshBalances();
-        }
-      }
+        },
+      };
     },
 
     parseBN(n) {
-       return n.div(10 ** 18)
-                  .decimalPlaces(6)
-                  .toString()
+      return n
+        .div(10 ** 18)
+        .decimalPlaces(6)
+        .toString();
     },
 
     async refreshBalances() {
@@ -226,7 +262,9 @@ export default {
         .balanceOf(this.userConnectedWalletAddress)
         .call();
       this.userOutputTokenBalance = BN(userOutputTokenBalance);
-      if (this.dev) console.log("userOutputTokenBalance", userOutputTokenBalance);
+      if (this.dev) {
+        console.log("userOutputTokenBalance", userOutputTokenBalance);
+      }
       return userOutputTokenBalance;
     },
 

--- a/src/components/Stake/Wrap.vue
+++ b/src/components/Stake/Wrap.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="w-5/6 max-w-2xl pt-40 mx-auto">
-    <section class="relative gap-4 p-6 my-10 text-white bg-gray-800 shadow-md rounded-xl">
+    <section
+      class="relative gap-4 p-6 my-10 text-white bg-gray-800 shadow-md rounded-xl"
+    >
       <span
-        class="absolute p-1 px-3 text-sm font-bold text-gray-200 transform -translate-x-1/2 rounded-full opacity-95 left-1/2 -top-3 bg-brand-primary">Beta</span>
+        class="absolute p-1 px-3 text-sm font-bold text-gray-200 transform -translate-x-1/2 rounded-full opacity-95 left-1/2 -top-3 bg-brand-primary"
+        >Beta</span
+      >
 
-      <Chooser :routes="this.routes" :currentActive="this.title == 'Wrap' ? 0 : 1" />
+      <Chooser
+        :routes="this.routes"
+        :currentActive="this.title == 'Wrap' ? 0 : 1"
+      />
 
       <div class="flex flex-col items-center justify-center">
         <header class="pb-3 my-4 text-center">
@@ -17,25 +24,41 @@
         </header>
 
         <!-- Progress - show completed steps status -->
-        <div class="pb-3 mb-6 border-b border-gray-700" v-if="userWalletIsConnected">
+        <div
+          class="pb-3 mb-6 border-b border-gray-700"
+          v-if="userWalletIsConnected"
+        >
           <aside class="flex flex-wrap justify-center gap-3 md:gap-6">
-            <Step :title="`Approve ${inputTokenName}`" :completed="this.depositStage" step="1" />
-            <Step :title="`Wrap ${inputTokenName}`" :completed="this.completed" step="2" />
+            <Step
+              :title="`Approve ${inputTokenName}`"
+              :completed="this.depositStage"
+              step="1"
+            />
+            <Step
+              :title="`Wrap ${inputTokenName}`"
+              :completed="this.completed"
+              step="2"
+            />
           </aside>
         </div>
 
         <label v-if="this.depositStage || this.approvalStage">
           <p class="text-sm font-semibold text-gray-300 mb-0.5">
-            How much {{inputTokenName}} would you like to stake for {{ outputTokenName }}?
+            How much {{ inputTokenName }} would you like to stake for
+            {{ outputTokenName }}?
           </p>
-          <div class="relative flex items-center gap-1 p-2 text-xl border border-gray-200 rounded-xl">
-            <input :value="amount" class="max-w-xs ml-2 text-white bg-transparent border-none outline-none" 
+          <div
+            class="relative flex items-center gap-1 p-2 text-xl border border-gray-200 rounded-xl"
+          >
+            <input
+              :value="amount"
+              class="max-w-xs ml-2 text-white bg-transparent border-none outline-none"
               :placeholder="
                 this.userTokenBalance
                   .div(10 ** 18)
                   .decimalPlaces(6)
                   .toString()
-              " 
+              "
               @input="
                 amount = isNaN(parseFloat($event.target.value))
                   ? 0
@@ -43,15 +66,19 @@
               "
             />
             <span class="text-sm">
-              {{inputTokenName}}
+              {{ inputTokenName }}
             </span>
-            <button @click="handleFillMaxAmount" v-if="true"
-              class=" px-1 py-0.5 text-xs font-semibold bg-white rounded text-brand-primary">
+            <button
+              @click="handleFillMaxAmount"
+              v-if="true"
+              class=" px-1 py-0.5 text-xs font-semibold bg-white rounded text-brand-primary"
+            >
               max
             </button>
           </div>
           <p class="text-sm font-semibold text-gray-300 mb-0.5">
-            Current {{outputTokenName}} Balance: {{ parseBN(userOutputTokenBalance) }} 
+            Current {{ outputTokenName }} Balance:
+            {{ parseBN(userOutputTokenBalance) }}
           </p>
         </label>
 
@@ -64,15 +91,26 @@
           <ConnectButton v-else-if="!userConnectedWalletAddress" />
 
           <template v-else>
-            <p v-if="!userHasTokenBalance" class="mt-2 text-sm font-semibold text-gray-200">
-              You need to have {{inputTokenName}} tokens in your wallet in order to continue
-              {{ outputTokenName }}.
+            <p
+              v-if="!userHasTokenBalance"
+              class="mt-2 text-sm font-semibold text-gray-200"
+            >
+              You need to have {{ inputTokenName }} tokens in your wallet in
+              order to continue {{ outputTokenName }}.
             </p>
 
-            <ApprovalButton v-else-if="stage == 'approvalStage'" :ABI_token="sgETH" :ABI_spender="wsgETH"
-              :amount="this.amount" :cb="getUserApproved" />
+            <ApprovalButton
+              v-else-if="stage == 'approvalStage'"
+              :ABI_token="sgETH"
+              :ABI_spender="wsgETH"
+              :amount="this.amount"
+              :cb="getUserApproved"
+            />
 
-            <dapp-tx-btn v-else-if="stage == 'depositStage'" :click="handleDeposit">
+            <dapp-tx-btn
+              v-else-if="stage == 'depositStage'"
+              :click="handleDeposit"
+            >
               <span> {{ this.title }}</span>
             </dapp-tx-btn>
           </template>
@@ -93,6 +131,7 @@ import Chooser from "../Common/Chooser.vue";
 import DappTxBtn from "../Common/DappTxBtn.vue";
 
 import ImageVue from "../Handlers/ImageVue.vue";
+import { toWei } from "../../utils/common";
 
 // Max unit is the maximum value that can be represented in Solidity
 // const MAX_UNIT = 2 ** 256 - 1;
@@ -108,7 +147,7 @@ export default {
     Step,
     ApprovalButton,
     Chooser,
-    DappTxBtn
+    DappTxBtn,
   },
 
   data() {
@@ -121,14 +160,17 @@ export default {
       error: false,
       dev: true, // change to true for log
       completed: false, // Full process completed (in one session)
-      routes: [{ text: 'Wrap', cb: this.routeClickCb }, { text: 'Unwrap', cb: this.routeClickCb }],
+      routes: [
+        { text: "Wrap", cb: this.routeClickCb },
+        { text: "Unwrap", cb: this.routeClickCb },
+      ],
       wsgETH: wsgETH,
       sgETH: sgETH,
       ABI: sgETH,
       title: "Wrap",
       descr: "Wrap sgETH to interest bearing wsgETH",
       outputTokenName: "wsgETH",
-      inputTokenName: "sgETH"
+      inputTokenName: "sgETH",
     };
   },
 
@@ -156,9 +198,7 @@ export default {
     userHasApprovedToken() {
       return (
         this.userApproved.gt(0) &&
-        this.userApproved.gte(
-          window.web3.utils.toWei(this.amount?.toString() || '0', "ether")
-        )
+        this.userApproved.gte(toWei(this.amount || 0))
       );
     },
 
@@ -176,27 +216,25 @@ export default {
       return (
         this.amount &&
         this.amount <
-        this.userTokenBalance
-          .div(10 ** 18)
-          .decimalPlaces(6)
-          .toString()
+          this.userTokenBalance
+            .div(10 ** 18)
+            .decimalPlaces(6)
+            .toString()
       );
     },
     approvalStage() {
       return this.userWalletIsConnected && !this.userHasApprovedToken;
     },
     depositStage() {
-      return (
-        this.userWalletIsConnected &&
-        this.userCanRequestWithdrawal
-      );
+      return this.userWalletIsConnected && this.userCanRequestWithdrawal;
     },
 
     completedStepsCount() {
       return this.approvalStage + this.depositStage + 1;
     },
 
-    stage() { // need to improve this. 
+    stage() {
+      // need to improve this.
       if (!this.userWalletIsConnected) return false;
       let state = {
         approvalStage: this.approvalStage,
@@ -216,17 +254,18 @@ export default {
     handleDeposit() {
       return {
         abiCall: this.wsgETH.methods.deposit,
-        argsArr: [window.web3.utils.toWei(this.amount, "ether"), this.userConnectedWalletAddress],
+        argsArr: [toWei(this.amount), this.userConnectedWalletAddress],
         cb: async () => {
           await this.refreshBalances();
-        }
-      }
+        },
+      };
     },
 
     parseBN(n) {
-       return n.div(10 ** 18)
-                  .decimalPlaces(6)
-                  .toString()
+      return n
+        .div(10 ** 18)
+        .decimalPlaces(6)
+        .toString();
     },
 
     async refreshBalances() {
@@ -260,7 +299,9 @@ export default {
         .balanceOf(this.userConnectedWalletAddress)
         .call();
       this.userOutputTokenBalance = BN(userOutputTokenBalance);
-      if (this.dev) console.log("userOutputTokenBalance", userOutputTokenBalance);
+      if (this.dev) {
+        console.log("userOutputTokenBalance", userOutputTokenBalance);
+      }
       return userOutputTokenBalance;
     },
 

--- a/src/components/Withdraw/RedemptionBase.vue
+++ b/src/components/Withdraw/RedemptionBase.vue
@@ -229,6 +229,7 @@ import DappTxBtn from "../Common/DappTxBtn.vue";
 
 import WithdrawalsFAQ from "./WithdrawalsFAQ.vue";
 import ImageVue from "../Handlers/ImageVue.vue";
+import { toWei } from "../../utils/common";
 
 // Max unit is the maximum value that can be represented in Solidity
 // const MAX_UNIT = 2 ** 256 - 1;
@@ -304,9 +305,7 @@ export default {
     userHasApprovedToken() {
       return (
         this.userApprovedVEth2.gt(0) &&
-        this.userApprovedVEth2.gte(
-          window.web3.utils.toWei(this.amount?.toString() || "0", "ether")
-        )
+        this.userApprovedVEth2.gte(toWei(this.amount?.toString() || "0"))
       );
     },
 
@@ -385,7 +384,7 @@ export default {
     handleDepositVEth2() {
       return {
         abiCall: this.ABI.methods.deposit,
-        argsArr: [window.web3.utils.toWei(this.amount, "ether")],
+        argsArr: [toWei(this.amount)],
         cb: this.refreshBalances,
       };
     },
@@ -437,13 +436,16 @@ export default {
     },
 
     async getOutputTokenBalance() {
-      let bal = await window.web3.eth.getBalance(
-        this.userConnectedWalletAddress
-      );
+      let bal = 0;
       if (this.outputTokenName.toLowerCase() == "sgeth") {
         bal = await sgETH.methods
           .balanceOf(this.userConnectedWalletAddress)
           .call();
+      } else {
+        bal = await window.ethereum.request({
+          method: "eth_getBalance",
+          params: [this.userConnectedWalletAddress, "latest"],
+        });
       }
       this.outputTokenBalance = BN(bal);
     },

--- a/src/components/Withdraw/Withdraw.vue
+++ b/src/components/Withdraw/Withdraw.vue
@@ -24,7 +24,7 @@ export default {
       title: "Withdraw",
       descr: "Goerli testnet withdrawals - Redeem vETH2 for ETH",
       ethAvailableForWithdrawal: BN(0),
-      outputTokenName: "ETH"
+      outputTokenName: "ETH",
     };
   },
   computed: {
@@ -32,9 +32,10 @@ export default {
   },
   methods: {
     async getEthAvailableForWithdrawal() {
-      const amt = await window.web3.eth.getBalance(
-        ABI_withdrawals.options.address
-      );
+      const amt = await window.ethereum.request({
+        method: "eth_getBalance",
+        params: [ABI_withdrawals.options.address, "latest"],
+      });
 
       this.ethAvailableForWithdrawal = BN(amt);
     },

--- a/src/store/init/onboard.js
+++ b/src/store/init/onboard.js
@@ -63,7 +63,6 @@ const onboard = Onboard({
     wallet: (wallet) => {
       console.log(`wallet switched to: ${wallet.name}`);
       let W3 = (window.web3 = new Web3(wallet.provider));
-      // console.log(window.web3)
       store.commit("setWeb3", W3);
       store.commit("setWallet", wallet.name);
       localStorage.setItem("selectedWallet", wallet.name);

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -5,57 +5,68 @@
 // import axios from "axios"
 
 export const getCurrentGasPrices = async () => {
-    // todo fix me
-    // let response = await axios.get('https://www.gasnow.org/api/v3/gas/price')
-    // let response = await axios.get('https://ethgasstation.info/api/ethgasAPI.json?');
-    // console.log('getCurrentGasPrices', response);
-    // if (!response || response.status !== 200) {
-    return {
-        low: 2,
-        medium: 30,
-        high: 200,
-        tip: {
-            low: 0.1,
-            medium: 1,
-            high: 2
-        }
-    }
-    // }
-    // return {
-    //     low: response.data.data.slow / 1e9,
-    //     medium: response.data.data.standard / 1e9,
-    //     high: response.data.data.fast / 1e9
-    // }
-}
+  // todo fix me
+  // let response = await axios.get('https://www.gasnow.org/api/v3/gas/price')
+  // let response = await axios.get('https://ethgasstation.info/api/ethgasAPI.json?');
+  // console.log('getCurrentGasPrices', response);
+  // if (!response || response.status !== 200) {
+  return {
+    low: 2,
+    medium: 30,
+    high: 200,
+    tip: {
+      low: 0.1,
+      medium: 1,
+      high: 2,
+    },
+  };
+  // }
+  // return {
+  //     low: response.data.data.slow / 1e9,
+  //     medium: response.data.data.standard / 1e9,
+  //     high: response.data.data.fast / 1e9
+  // }
+};
 import Notify from "bnc-notify";
 
 export const notify = Notify({
-    dappId: "ba574938-2a97-44e8-812f-653f9a6a499b", // [String] The API key created by step one above
-    networkId: 5, // [Integer] The Ethereum network ID your Dapp uses.
-    darkMode: true,
-    desktopPosition: "topRight",
+  dappId: "ba574938-2a97-44e8-812f-653f9a6a499b", // [String] The API key created by step one above
+  networkId: 5, // [Integer] The Ethereum network ID your Dapp uses.
+  darkMode: true,
+  desktopPosition: "topRight",
 });
 
 export function notifyHandler(hash) {
-    let { emitter } = notify.hash(hash);
-    let chain = window.ethereum.chainId == '0x5' ? 'goerli.' : '';
-    emitter.on("all", (transaction) => ({
-        onclick: () =>
-            window.open(
-                `https://${chain}etherscan.io/tx/${transaction.hash}`,
-                "_blank",
-                "noopener norefferer"
-            ) &&
-            console.log("notify handler tx", transaction),
-    }));
+  let { emitter } = notify.hash(hash);
+  let chain = window.ethereum.chainId == "0x5" ? "goerli." : "";
+  emitter.on("all", (transaction) => ({
+    onclick: () =>
+      window.open(
+        `https://${chain}etherscan.io/tx/${transaction.hash}`,
+        "_blank",
+        "noopener norefferer"
+      ) && console.log("notify handler tx", transaction),
+  }));
 }
 
 export function notifyNotification(message, type = "pending") {
-    let notificationObject = {
-        eventCode: "notification",
-        type: type,
-        message: message,
-    };
+  let notificationObject = {
+    eventCode: "notification",
+    type: type,
+    message: message,
+  };
 
-    return notify.notification(notificationObject);
+  return notify.notification(notificationObject);
+}
+
+import Web3 from "web3";
+const web3 = new Web3();
+export function toWei(value) {
+  console.log(web3);
+  if (!value || value == 0 || !value?.toString) return 0;
+  return web3.utils.toWei(value.toString(), "ether");
+}
+
+export function toChecksumAddress(address) {
+  return web3.utils.toChecksumAddress(address);
 }


### PR DESCRIPTION
* Fix default to sgETH on stake pages https://github.com/SharedStake/SharedStake-ui/issues/161
* When investigating [Firefox not working issue](https://github.com/SharedStake/SharedStake-ui/issues/152), I realised that metamask no longer supports use of window.web3 and instead asks to use window.ethereum for interactions. We were still using window.web3. I migrated all calls to use the new provider API as per their guide: https://docs.metamask.io/wallet/how-to/migrate-api/

I wasn't able to replicate Firefox issue initially, so would be good if someone who experienced it could test again once this is merged in.