### PR TITLE
 Gas price fix #145 #168 + StakeGuage format

### DIFF
--- a/src/components/Stake/StakeGauge.vue
+++ b/src/components/Stake/StakeGauge.vue
@@ -8,18 +8,20 @@
         {{ contractEtherLimit }}ETH is required (for
         {{ numOfValidators }} validators).<br />
         When ETH is deposited into the SharedDeposit contract, a
-        Validator-Share-ETH2 / SharedStake Governed Ether token (SGEth) is minted. 
-        SGEth is then optionally wrapped into wsgETH to earn interest from validators.  
-        Redeemable for the
-        deposited ETH.
+        Validator-Share-ETH2 / SharedStake Governed Ether token (SGEth) is
+        minted. SGEth is then optionally wrapped into wsgETH to earn interest
+        from validators. Redeemable for the deposited ETH.
       </div>
     </div>
     <vep
       :loading="loading"
       :progress="contractDepositRatio"
       :legend-value="ethDeposited"
-      :legendFormatter="({currentValue}) => new Intl.NumberFormat('en-US').format(currentValue)"
-      :size="180"
+      :legendFormatter="
+        ({ currentValue }) =>
+          new Intl.NumberFormat('en-US').format(currentValue)
+      "
+      :size="220"
       :thickness="5"
       :empty-thickness="3"
       color="rgb(37, 167, 219)"
@@ -27,18 +29,19 @@
       empty-color="#181818"
       empty-color-fill="#181818"
       lineMode="in"
-      animation="loop 700 1000"
-      fontSize="1.5rem"
+      animation="700 1000"
+      fontSize="2rem"
       font-color="white"
+ 
     >
-      <span slot="legend-value">
-        of {{ maxEthDepositOnContract.toLocaleString('en-US') }}
-        <ImageVue :src="'tokens/eth-logo.png'" :size="'20px'" />
-      </span>
+      <div slot="legend-value" class=" text-sm">
+        / {{ maxEthDepositOnContract.toLocaleString("en-US") }}
+      </div>
 
-      <span slot="legend-caption">
-        <span class="blue">ETH staked</span>
-      </span>
+      <div slot="legend-caption" class="flex flex-row gap-2">
+        <ImageVue :src="'tokens/eth-logo.png'" :size="'20px'" />
+        <div class="blue">ETH Staked</div>
+      </div>
     </vep>
   </div>
 </template>
@@ -85,11 +88,15 @@ export default {
       let validatorPrice = await validator.methods.costPerValidator().call();
       this.numOfValidators = await validator.methods.numValidators().call();
 
-      maxValidatorShares = BN(maxValidatorShares).dividedBy(1e18).toFixed(2);
+      maxValidatorShares = BN(maxValidatorShares)
+        .dividedBy(1e18)
+        .toFixed(2);
       currentValidatorShares = BN(currentValidatorShares)
         .dividedBy(1e18)
         .toFixed(2);
-      validatorPrice = BN(validatorPrice).dividedBy(1e18).toFixed(2);
+      validatorPrice = BN(validatorPrice)
+        .dividedBy(1e18)
+        .toFixed(2);
 
       this.ethDeposited = this.calculateEthDepositted(
         currentValidatorShares,
@@ -119,16 +126,15 @@ export default {
       const stakePerValidator = 32;
       let ethDepositedToContract =
         (currentValidatorShares * validatorPrice) / stakePerValidator;
-      
+
       const v1 = stakePerValidator * 500;
       ethDepositedToContract += v1;
       // To 2 decimal accuracy and cast it to number
       return +ethDepositedToContract.toFixed(2);
-    }
-  }
+    },
+  },
 };
 </script>
-
 
 <style scoped>
 .gauge {

--- a/src/store/init/onboard.js
+++ b/src/store/init/onboard.js
@@ -8,7 +8,7 @@ import store from "../index";
 const INFURA_KEY = "623c40ea76b44f068428108587d37f4e";
 const APP_URL = "https://www.sharedstake.org/";
 const CONTACT_EMAIL = "chimera_defi@protonmail.com";
-const RPC_URL = "https://mainnet.infura.io/v3/623c40ea76b44f068428108587d37f4e";
+export const RPC_URL = "https://mainnet.infura.io/v3/623c40ea76b44f068428108587d37f4e";
 const APP_NAME = "SharedStake";
 
 const wallets = [


### PR DESCRIPTION
# Description
 
Modified: 
- _src/utils/common.js_ 
- _src/store/init/onboard.js_
- _src/components/Stake/StakeGauge.vue_

Hardcoded gas fee has been replaced with the web3.js getGasPrice call ([doc](https://web3js.readthedocs.io/en/v1.5.0/web3-eth.html?highlight=getGasPrice#getgasprice)).

Breakdown of multiplies for gas fees and values of priority fee:
```
low: lowGasPrice, // Here we're assuming low is 80% of the current gas price but a min of 2100wei.
medium: gasPriceInGwei,
high: gasPriceInGwei * 1.2, // Here we're assuming high is 120% of the current gas price.
   tip: {
      low: 1, // Adjust these priority fees as you see fit.
      medium: 2,
      high: 5,
   },
```

The Infura API key has also been exported from the onboard.js file and imported into the common.js where the web3 instance is initiated.

Some error handling was also added.

Fixes #145 #168

Stakeguage slid in with a commit too, fixed some formatting
![Screenshot 2023-07-25 at 00 27 17](https://github.com/SharedStake/SharedStake-ui/assets/52243165/13cd953d-97a2-427b-8a36-5402a9c6180f)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing

- [x] Printing gas + tip to console 
_Note: debugging has been removed for prod._
![image](https://github.com/SharedStake/SharedStake-ui/assets/52243165/d0e8f231-2139-40ce-99ce-0b8ec8bf497c)

- [ ] Unable to confirm with transaction ... I don't have any tokens to test with... yet 

