### PR TITLE
feat: add total redeemed tracking on rollover/withdraw

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@gnosis.pm/safe-apps-onboard": "^0.3.0",
     "@gnosis.pm/safe-apps-sdk": "^2.3.0",
-    "@web3-onboard/gas": "^2.1.8",
+    "@web3-onboard/gas": "2.1.8",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "bnc-notify": "^1.5.1",

--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -10,11 +10,13 @@
       </div>
       <div class="flex flex-col justify-center h-full p-4">
         <div class="mb-8 text-center md-large:max-w-xl md-large:text-left">
-          <h1 class="mb-6 mainTitle">Simple Ethereum 2.0 Staking</h1>
+          <h1 class="mb-6 mainTitle">ETHEREUM LIQUID STAKING DERIVATIVE! <br /> EST 2020.</h1>
           <div class="exp">
             SharedStake is a decentralized Ethereum 2 staking solution that
             allows users to stake any amount of Ether and earn additional yield
             on top of their ETH2 rewards.
+            <br /><b> V2 LIVE NOW! </b>
+            <br /><b> V1 Redemptions LIVE NOW at 1.1 Eth per vETH2. </b>
           </div>
         </div>
         <div
@@ -24,7 +26,7 @@
             class="px-6 py-3 text-xl font-semibold transition-all border-2 border-transparent rounded-full bg-brand-primary md:font-medium md:text-3xl md:px-8 hover:bg-transparent hover:text-brand-primary hover:border-brand-primary whitespace-nowrap"
             to="/stake"
           >
-            STAKE
+            STAKE V2
           </router-link>
           <a
             class="px-6 py-3 text-xl font-medium transition-all border border-white rounded-full whitespace-nowrap md:text-2xl hover:border-brand-primary hover:text-brand-primary md:px-8"

--- a/src/components/Landing/Partners.vue
+++ b/src/components/Landing/Partners.vue
@@ -31,20 +31,20 @@ export default {
             "https://v2.info.uniswap.org/pair/0x3d07f6e1627DA96B8836190De64c1aED70e3FC55/",
           key: 1,
         },
-        {
-          name: "Ruler",
-          imageUrl: "ruler.png",
-          text: "Use Ruler to get loans using vETH2 as collateral!",
-          link: "https://rulerprotocol.com/",
-          key: 2,
-        },
-        {
-          name: "Saddle",
-          imageUrl: "saddle.png",
-          text: "vETH2 liquidity pool provider.",
-          link: "https://saddle.finance",
-          key: 3,
-        },
+        // {
+        //   name: "Ruler",
+        //   imageUrl: "ruler.png",
+        //   text: "Use Ruler to get loans using vETH2 as collateral!",
+        //   link: "https://rulerprotocol.com/",
+        //   key: 2,
+        // },
+        // {
+        //   name: "Saddle",
+        //   imageUrl: "saddle.png",
+        //   text: "vETH2 liquidity pool provider.",
+        //   link: "https://saddle.finance",
+        //   key: 3,
+        // },
         {
           name: "Defi Pulse",
           imageUrl: "defipulse.png",
@@ -60,6 +60,13 @@ export default {
             "The most trusted platform to manage digital assets on Ethereum.",
           link: "https://gnosis.io/",
           key: 5,
+        },
+        {
+          name: "Bunni.pro",
+          imageUrl: "uniswap.png",
+          text: "Earn yield on your univ3 position using bunni",
+          link: "https://bunni.pro/",
+          key: 6,
         },
         {
           name: "Immunefi",

--- a/src/components/Navigation/Menu.vue
+++ b/src/components/Navigation/Menu.vue
@@ -45,6 +45,12 @@
         <DropdownItemAnchor href="https://sharedtools.org">
           SharedTools
         </DropdownItemAnchor>
+        <DropdownItemAnchor href="https://discord.gg/C9GhCv86My">
+          Discord
+        </DropdownItemAnchor>
+        <DropdownItemAnchor href="https://t.me/SharedStakeFinance">
+          Telegram
+        </DropdownItemAnchor>
         <DropdownItemAnchor href="https://twitter.com/ChimeraDefi">
           Twitter
         </DropdownItemAnchor>

--- a/src/components/Withdraw/RedemptionBase.vue
+++ b/src/components/Withdraw/RedemptionBase.vue
@@ -211,6 +211,7 @@
         :ethAvailableForWithdrawal="ethAvailableForWithdrawal"
         :veth2Bal="contractVeth2Bal"
         :userBal="userVEth2Balance"
+        :totalRedeemed="totalRedeemed"
       />
     </section>
   </div>
@@ -255,6 +256,8 @@ export default {
     "descr",
     "getEthAvailableForWithdrawal",
     "ethAvailableForWithdrawal",
+    'getTotalRedeemed',
+    'totalRedeemed',
     "outputTokenName",
   ],
 
@@ -466,6 +469,7 @@ export default {
       await this.getUserDepositedVEth2();
       await this.getContractVeth2Queue();
       await this.getEthAvailableForWithdrawal();
+      await this.getTotalRedeemed();
     },
 
     handleFillMaxAmount() {

--- a/src/components/Withdraw/Rollover.vue
+++ b/src/components/Withdraw/Rollover.vue
@@ -6,6 +6,8 @@
     :getEthAvailableForWithdrawal="getEthAvailableForWithdrawal"
     :ethAvailableForWithdrawal="ethAvailableForWithdrawal"
     :outputTokenName="outputTokenName"
+    :totalRedeemed="totalRedeemed"
+    :getTotalRedeemed="getTotalRedeemed"
   />
 </template>
 
@@ -23,8 +25,8 @@ export default {
       ABI: ABI_Rollover,
       title: "Rollover",
       descr: "Redeem vETH2 for sgETH",
-      getEthAvailableForWithdrawal: this.getEthAvailableForRollovers,
       ethAvailableForWithdrawal: BN(0),
+      totalRedeemed: BN(0),
       outputTokenName: "sgETH"
     };
   },
@@ -32,12 +34,16 @@ export default {
     ...mapGetters({ userConnectedWalletAddress: "userAddress" }),
   },
   methods: {
-    async getEthAvailableForRollovers() {
+    async getEthAvailableForWithdrawal() {
       let amt = await ABI_sgETH.methods
         .balanceOf(ABI_Rollover.options.address)
         .call();
       this.ethAvailableForWithdrawal = BN(amt);
     },
+    async getTotalRedeemed() {
+      let amt = await ABI_Rollover.methods.totalOut().call();
+      this.totalRedeemed = BN(amt);
+    }
   },
 };
 </script>

--- a/src/components/Withdraw/Withdraw.vue
+++ b/src/components/Withdraw/Withdraw.vue
@@ -6,6 +6,8 @@
     :getEthAvailableForWithdrawal="getEthAvailableForWithdrawal"
     :ethAvailableForWithdrawal="ethAvailableForWithdrawal"
     :outputTokenName="outputTokenName"
+    :totalRedeemed="totalRedeemed"
+    :getTotalRedeemed="getTotalRedeemed"
   />
 </template>
 
@@ -24,6 +26,7 @@ export default {
       title: "Withdraw",
       descr: "Withdrawals - Redeem vETH2 for ETH",
       ethAvailableForWithdrawal: BN(0),
+      totalRedeemed: BN(0),
       outputTokenName: "ETH",
     };
   },
@@ -39,6 +42,12 @@ export default {
 
       this.ethAvailableForWithdrawal = BN(amt);
     },
+
+    async getTotalRedeemed() {
+      let amt = await ABI_withdrawals.methods.totalOut().call();
+      console.log(BN(amt), 'asfaf')
+      this.totalRedeemed = BN(amt);
+    }
   },
 };
 </script>

--- a/src/components/Withdraw/Withdraw.vue
+++ b/src/components/Withdraw/Withdraw.vue
@@ -45,7 +45,6 @@ export default {
 
     async getTotalRedeemed() {
       let amt = await ABI_withdrawals.methods.totalOut().call();
-      console.log(BN(amt), 'asfaf')
       this.totalRedeemed = BN(amt);
     }
   },

--- a/src/components/Withdraw/WithdrawalsFAQ.vue
+++ b/src/components/Withdraw/WithdrawalsFAQ.vue
@@ -45,17 +45,21 @@
         There is {{
           veth2Bal.div(10 ** 18)
             .decimalPlaces(6)
-            .toString() }} vETH2 deposited here.
+            .toString() }} vETH2 deposited here. 
+        Redeemable for {{
+          veth2Bal.div(1/1.1).div(10 ** 18)
+            .decimalPlaces(6)
+            .toString()  }} tokens.
         <br />
-        Of which {{
+        From which {{
           totalRedeemed.div(10 ** 18)
             .decimalPlaces(6).toString()
-        }} has already been redeemed.
+        }} tokens have already been redeemed.
         <br />
         A total of {{
-          (veth2Bal
+          (veth2Bal.multipliedBy(11).div(10)
             .minus(totalRedeemed)
-            .minus(ethAvailableForWithdrawal.div(1 / 1.1))
+            .minus(ethAvailableForWithdrawal)
           ).div(10 ** 18)
             .decimalPlaces(6)
             .toString()
@@ -71,7 +75,7 @@
         You can withdraw upto {{
           ethAvailableForWithdrawal.div(10 ** 18)
             .decimalPlaces(6)
-            .toString() }} ETH buffered in the contract right now.
+            .toString() }} ETH buffered in the contract. Right now! 
       </template>
     </QuestionAnswer>
 

--- a/src/components/Withdraw/WithdrawalsFAQ.vue
+++ b/src/components/Withdraw/WithdrawalsFAQ.vue
@@ -44,7 +44,18 @@
             There is {{
             veth2Bal.div(10 ** 18)
             .decimalPlaces(6)
-            .toString()}} vETH2 queued here. 
+            .toString()}} vETH2 deposited here. 
+            <br />
+            Of which {{ 
+              totalRedeemed.div(10 ** 18)
+                .decimalPlaces(6).toString()
+            }} has already been redeemed. 
+            <br />
+            A total of {{ 
+            (veth2Bal.minus(totalRedeemed).minus(ethAvailableForWithdrawal.div(1/1.1))).div(10 ** 18)
+            .decimalPlaces(6)
+            .toString()
+            }} vETH2 is queued. (if the number is negative that means there's excess in the buffer)
           </template>
         </QuestionAnswer>
 
@@ -78,6 +89,6 @@ import QuestionAnswer from "@/components/Withdraw/QuestionAnswer.vue";
 export default {
   name: 'WithdrawalsFAQ',
   components: {QuestionAnswer},
-  props: ['ethAvailableForWithdrawal', 'veth2Bal', 'userBal'],
+  props: ['ethAvailableForWithdrawal', 'totalRedeemed', 'veth2Bal', 'userBal'],
 }
 </script>

--- a/src/components/Withdraw/WithdrawalsFAQ.vue
+++ b/src/components/Withdraw/WithdrawalsFAQ.vue
@@ -1,86 +1,91 @@
 <template>
-  
   <div class="mt-10 text-white">
-        <h2 class="mb-4 text-2xl font-medium text-center">
-          Frequently Asked Questions
-        </h2>
+    <h2 class="mb-4 text-2xl font-medium text-center">
+      Frequently Asked Questions
+    </h2>
 
-        <QuestionAnswer>
-          <template #question>
-            How do I withdraw my staked ETH?
-          </template>
-          <template #answer>
-            You can withdraw your staked ETH by following the steps:
-            <br />
-            <strong>Step 1:</strong> Approve vETH2
-            <br />
-            <strong>Step 2:</strong> Deposit vETH2
-            <br />
-            <strong>Step 3:</strong> Withdraw
-            <br />
-            <strong>Note: You must deposit vETH2 first. ETH or tokens will then be buffered into the contract based on demand</strong>
-          </template>
-        </QuestionAnswer>
+    <QuestionAnswer>
+      <template #question>
+        How do I withdraw my staked ETH?
+      </template>
+      <template #answer>
+        You can withdraw your staked ETH by following the steps:
+        <br />
+        <strong>Step 1:</strong> Approve vETH2
+        <br />
+        <strong>Step 2:</strong> Deposit vETH2
+        <br />
+        <strong>Step 3:</strong> Withdraw
+        <br />
+        <strong>Note: You must deposit vETH2 first. ETH or tokens will then be buffered into the contract based on
+          demand</strong>
+      </template>
+    </QuestionAnswer>
 
-        <QuestionAnswer>
-          <template #question>
-            How much is vETH2 worth? (Redemption rate)
-          </template>
-          <template #answer>
-            The rate is 1.1 
-            i.e. 1 vETH2 = 1.1 ETH.
-            <p v-if="userBal > 0">
-            OR
-            {{ userBal.div(10 ** 18).decimalPlaces(6).toString() }} vETH2 = {{ userBal.div(1/1.1).div(10 ** 18).decimalPlaces(6).toString() }} ETH/sgETH
-            </p>
-          </template>
-        </QuestionAnswer>
+    <QuestionAnswer>
+      <template #question>
+        How much is vETH2 worth? (Redemption rate)
+      </template>
+      <template #answer>
+        The rate is 1.1
+        i.e. 1 vETH2 = 1.1 ETH.
+        <p v-if="userBal > 0">
+          OR
+          {{ userBal.div(10 ** 18).decimalPlaces(6).toString() }} vETH2 = {{ userBal.div(1 / 1.1).div(10 **
+            18).decimalPlaces(6).toString() }} ETH/sgETH
+        </p>
+      </template>
+    </QuestionAnswer>
 
-        <QuestionAnswer>
-          <template #question>
-            How much vETH2 is staked in this contract?
-          </template>
-          <template #answer>
-            There is {{
-            veth2Bal.div(10 ** 18)
+    <QuestionAnswer>
+      <template #question>
+        How much vETH2 is staked in this contract?
+      </template>
+      <template #answer>
+        There is {{
+          veth2Bal.div(10 ** 18)
             .decimalPlaces(6)
-            .toString()}} vETH2 deposited here. 
-            <br />
-            Of which {{ 
-              totalRedeemed.div(10 ** 18)
-                .decimalPlaces(6).toString()
-            }} has already been redeemed. 
-            <br />
-            A total of {{ 
-            (veth2Bal.minus(totalRedeemed).minus(ethAvailableForWithdrawal.div(1/1.1))).div(10 ** 18)
+            .toString() }} vETH2 deposited here.
+        <br />
+        Of which {{
+          totalRedeemed.div(10 ** 18)
+            .decimalPlaces(6).toString()
+        }} has already been redeemed.
+        <br />
+        A total of {{
+          (veth2Bal
+            .minus(totalRedeemed)
+            .minus(ethAvailableForWithdrawal.div(1 / 1.1))
+          ).div(10 ** 18)
             .decimalPlaces(6)
             .toString()
-            }} vETH2 is queued. (if the number is negative that means there's excess in the buffer)
-          </template>
-        </QuestionAnswer>
+        }} vETH2 is queued. (if the number is negative that means there's excess in the buffer)
+      </template>
+    </QuestionAnswer>
 
-        <QuestionAnswer>
-          <template #question>
-            How much can be withdrawn right now?
-          </template>
-          <template #answer>
-            You can withdraw upto {{
-            ethAvailableForWithdrawal.div(10 ** 18)
+    <QuestionAnswer>
+      <template #question>
+        How much can be withdrawn right now?
+      </template>
+      <template #answer>
+        You can withdraw upto {{
+          ethAvailableForWithdrawal.div(10 ** 18)
             .decimalPlaces(6)
-            .toString()}} ETH buffered in the contract right now.
-          </template>
-        </QuestionAnswer>
+            .toString() }} ETH buffered in the contract right now.
+      </template>
+    </QuestionAnswer>
 
-        <QuestionAnswer>
-          <template #question>
-            How long does it take to withdraw my ETH?
-          </template>
-          <template #answer>
-            It takes 7-14 days to withdraw your ETH. This is because the ETH you
-            staked is locked in the Ethereum 2.0 deposit contract and validators need to have their withdrawal addresses changed, then exited wherein they enter the exit queue. 
-          </template>
-        </QuestionAnswer>
-      </div>
+    <QuestionAnswer>
+      <template #question>
+        How long does it take to withdraw my ETH?
+      </template>
+      <template #answer>
+        It takes 7-14 days to withdraw your ETH. This is because the ETH you
+        staked is locked in the Ethereum 2.0 deposit contract and validators need to have their withdrawal addresses
+        changed, then exited wherein they enter the exit queue.
+      </template>
+    </QuestionAnswer>
+  </div>
 </template>
 
 <script>
@@ -88,7 +93,12 @@ import QuestionAnswer from "@/components/Withdraw/QuestionAnswer.vue";
 
 export default {
   name: 'WithdrawalsFAQ',
-  components: {QuestionAnswer},
-  props: ['ethAvailableForWithdrawal', 'totalRedeemed', 'veth2Bal', 'userBal'],
+  components: { QuestionAnswer },
+  props: [
+    'ethAvailableForWithdrawal',
+    'totalRedeemed',
+    'veth2Bal',
+    'userBal'
+  ],
 }
 </script>


### PR DESCRIPTION
Adds a section to the withdraw faq looking at the onchain contract report of how much has already been redeemed by users. 
And hints if theres excess / queued eth in the redemptions contracts. 
works on the /rollover and /withdraw pages