### PR TITLE
Update page copyright to current year

### DIFF
--- a/src/Root.vue
+++ b/src/Root.vue
@@ -290,7 +290,7 @@
           </div>
         </div>
       </div>
-      <div class="bottom">SharedStake © 2021</div>
+      <div class="bottom">SharedStake © 2025</div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Update copyright year to 2025 to reflect the current year.

---
<a href="https://cursor.com/background-agent?bcId=bc-246984b4-dc4e-428c-a15d-0ca1e64d8120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-246984b4-dc4e-428c-a15d-0ca1e64d8120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

