### PR TITLE
Contact us button

### DIFF
--- a/src/Root.vue
+++ b/src/Root.vue
@@ -227,6 +227,12 @@
             Coming Soon
           </div>
         </div>
+        <span class="link">
+          <a
+            href="mailto:admin@sharedstake.org"
+          >Contact Us
+          </a>
+        </span>
       </div>
 
       <!-- Trading Section -->
@@ -394,6 +400,11 @@
             <span class="link footerLink">
               <router-link to="/terms">Terms of Service </router-link>
             </span>
+            <span class="link footerLink">
+              <a
+                href="mailto:admin@sharedstake.org"
+              >Contact Us
+              </a></span>
           </div>
         </div>
       </div>

--- a/src/components/Navigation/Menu.vue
+++ b/src/components/Navigation/Menu.vue
@@ -72,6 +72,9 @@
         <DropdownItemAnchor href="https://twitter.com/ChimeraDefi">
           Twitter
         </DropdownItemAnchor>
+        <DropdownItemAnchor href="mailto:admin@sharedstake.org">
+          Contact Us
+        </DropdownItemAnchor>
       </DropdownGroup>
     </div>
 


### PR DESCRIPTION
Add a "Contact Us" button/link to the site that emails `admin@sharedstake.org`.

This PR adds the "Contact Us" link in three locations: the footer under the "About" section, the mobile sidebar under the "Community" section, and the desktop navigation menu within the "Learn" dropdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-014220e8-89f4-43c3-b19d-79b66e1fe522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-014220e8-89f4-43c3-b19d-79b66e1fe522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

