### PR TITLE
chore(repo): add lockfile-driven deps installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ pnpm-lock.yaml
 *.sw?
 
 # devNotes.md // create a new repo when everyting is done we don't want people to know this shit
+
+# Local assistant/worktree directories
+.claude/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Vue.js implementation of SharedStake DeFi protocol with optimized Bun-based buil
 # Install Bun (if not already installed)
 curl -fsSL https://bun.sh/install | bash
 
-# Install dependencies
-bun install
+# Install dependencies (lockfile-driven: bun/pnpm/npm)
+bash scripts/install-deps.sh
+# or: bun run deps:install
 
 # Start development server
 bun run dev

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bun": ">=1.0.0"
   },
   "scripts": {
-    "setup": "bun install && bash scripts/install-pre-commit-hook.sh",
+    "setup": "bash scripts/install-deps.sh && bash scripts/install-pre-commit-hook.sh",
     "postinstall": "bash scripts/install-pre-commit-hook.sh",
     "serve": "vite",
     "build": "vite build",
@@ -33,7 +33,8 @@
     "analyze:security": "bun audit --level moderate",
     "pre-commit": "bash scripts/pre-commit-check.sh",
     "pre-commit:fix": "bash scripts/fix-pre-commit-issues.sh",
-    "pre-commit:install": "bash scripts/install-pre-commit-hook.sh"
+    "pre-commit:install": "bash scripts/install-pre-commit-hook.sh",
+    "deps:install": "bash scripts/install-deps.sh"
   },
   "dependencies": {
     "@babel/core": "7.29.0",

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+has() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if [[ -f bun.lock || -f bun.lockb ]]; then
+  if ! has bun; then
+    echo "[deps] bun lockfile detected but bun is not installed (or not in PATH)." >&2
+    echo "[deps] Install bun: https://bun.sh/docs/installation" >&2
+    echo "[deps] Or run 'npm install' manually as a Node.js fallback." >&2
+    exit 1
+  fi
+
+  echo "[deps] bun lockfile detected -> bun install"
+  exec bun install "$@"
+elif [[ -f pnpm-lock.yaml ]]; then
+  echo "[deps] pnpm lockfile detected -> corepack pnpm install"
+  corepack enable >/dev/null 2>&1 || true
+  exec corepack pnpm install "$@"
+elif [[ -f package-lock.json ]]; then
+  echo "[deps] npm lockfile detected -> npm ci"
+  exec npm ci "$@"
+elif [[ -f yarn.lock ]]; then
+  echo "[deps] yarn lockfile detected -> corepack yarn install --frozen-lockfile"
+  corepack enable >/dev/null 2>&1 || true
+  exec corepack yarn install --frozen-lockfile "$@"
+else
+  echo "[deps] no lockfile found -> npm install"
+  exec npm install "$@"
+fi


### PR DESCRIPTION
**Agent:** GPT-5.3 Codex

## Summary
- add lockfile-driven dependency installer script
- wire setup/deps:install scripts to use installer
- document install flow in README
- ignore local assistant/worktree dirs (.claude/.worktrees)

## Original Request
> Finish remaining dependency/caching optimization and PR prep work for SharedStake-ui.

## Changes Made
- added scripts/install-deps.sh
- updated package.json scripts (setup, deps:install)
- updated README install instructions
- updated .gitignore for local assistant/worktree dirs

**Co-authored-by:** Chimera <chimera_defi@protonmail.com>