### PR TITLE
fix(landing): remove LearnMore double-box, polish subscribe section

### DIFF
--- a/src/components/Common/MailingListSubscribeForm.vue
+++ b/src/components/Common/MailingListSubscribeForm.vue
@@ -6,15 +6,14 @@
       src="https://airtable.com/embed/appLwrNK2W0XvoRUh/pagZv9w6lio5qp40F/form?backgroundColor=gray"
       frameborder="0"
       width="100%"
-      height="320"
     />
     <div class="fallback">
-      Prefer a full page? Open the
+      Prefer a full page?
       <a
         href="https://airtable.com/appLwrNK2W0XvoRUh/pagZv9w6lio5qp40F/form"
         target="_blank"
         rel="noopener noreferrer"
-      >signup form</a>.
+      >Open the signup form</a>.
     </div>
   </div>
 </template>
@@ -22,27 +21,33 @@
 <style scoped>
 .signup {
   width: 100%;
-  max-width: 860px;
+  max-width: 720px;
   margin: 0 auto;
   padding: 0 16px;
 }
 
 .airtable-frame {
   background: transparent;
-  border: 2px solid #fff;
-  border-radius: 12px;
-  height: clamp(360px, 60vh, 520px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  height: clamp(320px, 50vh, 440px);
+  box-shadow: 0 4px 32px rgba(0, 0, 0, 0.3);
 }
 
 .fallback {
   margin-top: 0.75rem;
   text-align: center;
-  font-size: 14px;
-  color: #fff;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .fallback a {
-  color: #fff;
+  color: rgba(255, 255, 255, 0.7);
   text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.fallback a:hover {
+  color: #fff;
 }
 </style>

--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -1485,6 +1485,8 @@ export default {
   height: 100%;
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
   transition: left 0.5s;
+}
+
 .LearnButton.enhanced-learn-button:hover::before {
   left: 100%;
 }

--- a/src/components/Landing/Landing.vue
+++ b/src/components/Landing/Landing.vue
@@ -286,15 +286,14 @@
             token with a 1:1 price ratio with Ether. vEth2 staking is also
             incentivized further with SGT, the SharedStake Governance Token.
           </div>
-          <div class="LearnButton">
-            <a
-              href="https://docs.sharedstake.finance/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Learn More
-            </a>
-          </div>
+          <a
+            class="LearnButton"
+            href="https://docs.sharedstake.finance/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn More
+          </a>
         </div>
       </div>
     </div>
@@ -385,14 +384,14 @@
           />
         </div>
       </div>
-      <div class="LearnButton">
-        <a
-          href="https://sips.sharedstake.org/SIPS/sip-3.html"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="px-6 py-3 text-base font-medium border border-[#e6007a] rounded-lg text-white hover:bg-[#e6007a]/20 transition-all duration-300"
-        >Learn More</a>
-      </div>
+      <a
+        class="LearnButton enhanced-learn-button"
+        href="https://sips.sharedstake.org/SIPS/sip-3.html"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Learn More
+      </a>
     </div>
     <div v-show="scrolled > 3800">
       <Partners />
@@ -552,11 +551,14 @@
     </div>
     <div
       id="email-signup"
-      class="flex_column"
+      class="email-signup-section"
     >
-      <div class="exp Information">
+      <div class="exp Information email-signup-info">
         <div class="InfoHeader centertext">
-          Subscribe for updates from the team
+          Stay in the loop
+        </div>
+        <div class="exp centertext email-signup-desc">
+          Get the latest on vETH2 staking rewards, governance proposals, and new DeFi integrations — straight from the team.
         </div>
         <div class="exp Info">
           <MailingListSubscribeForm />
@@ -1466,6 +1468,31 @@ export default {
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
 }
 
+/* Enhanced learn button */
+.LearnButton.enhanced-learn-button {
+  background: linear-gradient(135deg, #e6007a 0%, #b0005c 100%);
+  border: 2px solid rgba(230, 0, 122, 0.4);
+  position: relative;
+  overflow: hidden;
+}
+
+.LearnButton.enhanced-learn-button::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.5s;
+.LearnButton.enhanced-learn-button:hover::before {
+  left: 100%;
+}
+
+.LearnButton.enhanced-learn-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 8px 25px rgba(230, 0, 122, 0.4);
+}
 .downSign {
   display: flex;
   justify-content: center;
@@ -1574,10 +1601,11 @@ export default {
 }
 
 .LearnButton {
+  display: inline-block;
   width: fit-content;
   margin: 24px auto 0;
   font-size: 21px;
-  padding: 0.5rem 1.5rem 0.5rem 1.5rem;
+  padding: 0.5rem 1.5rem;
   border: 2px solid #fff;
   border-radius: 10px;
   text-align: center;
@@ -1585,9 +1613,10 @@ export default {
   cursor: pointer;
   z-index: 3;
   grid-area: Button;
+  color: #fff;
 }
 
-.LearnButton:hover,
+.LearnButton:hover:not(.enhanced-learn-button),
 .StakeButton:hover {
   transform: scale(0.98);
 }
@@ -2168,6 +2197,32 @@ body .roadMap .mainBox .main::-webkit-scrollbar {
 @media only screen and (max-width: 375px) {
   .mainTitle {
     font-size: 36px;
+  }
+}
+
+.email-signup-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 1rem;
+}
+
+.email-signup-info {
+  grid-area: unset;
+  width: min(70%, 860px);
+}
+
+.email-signup-desc {
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 640px;
+  margin: 0 auto 2rem;
+}
+
+@media only screen and (max-width: 900px) {
+  .email-signup-info {
+    width: 90%;
   }
 }
 </style>


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6

**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- Learn More button no longer shows a box-inside-a-box
- Subscribe section has better copy and visual treatment
- Enhanced Learn More button uses brand pink instead of off-brand purple

## Original Request
> think hard and do a few more passes on design review as I see many errors on the landing page. The Learn More button has another box inside it. Subscribe for updates section could maybe be a bit better.

## Changes Made
- **LearnButton double-box fix**: collapsed `<div class="LearnButton"><a>` nesting into a single `<a class="LearnButton">` element — the outer div border + inner anchor were rendering as two separate visible boxes; added `display: inline-block` and explicit `color: #fff` to the CSS rule
- **enhanced-learn-button**: replaced off-brand blue-purple gradient (`#667eea→#764ba2`) with brand pink (`#e6007a→#b0005c`); removed `background-clip: padding-box` + `border: 2px solid transparent` combination that was creating a second visible ring around the button; updated hover box-shadow to match
- **Subscribe section layout**: replaced undefined `flex_column` class with a proper `email-signup-section` flex container; added `email-signup-info` scoping rule to prevent `grid-area: Information` from leaking outside its grid context
- **Subscribe section copy**: heading changed from "Subscribe for updates from the team" → "Stay in the loop"; added subtitle describing what subscribers receive
- **MailingListSubscribeForm**: iframe border changed from `2px solid #fff` (harsh) to `1px solid rgba(255,255,255,0.15)` with a soft `box-shadow`; reduced max-height from 520px → 440px to reduce empty space; fallback link made subtler with hover-to-white transition