### PR TITLE
chore(delegate): source delegate-skill routing block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,29 @@ All Devin calls MUST route through the skill wrapper. Direct `devin --print` and
 - If Devin asks for clarification, use Codex guidance first and Claude second before asking a human.
 - Inspect telemetry regularly (`./skills/devin-delegate/scripts/devin_delegate_telemetry.py summary --days 14`).
 <!-- devin-delegate:end -->
+
+<!-- delegate-skill:begin -->
+## AI Delegation Routing
+
+> Canonical routing table lives in `~/.claude/skills/delegate-skill/SKILL.md`. This block
+> mirrors it for non-Claude agents. Keep the two in sync when routing changes.
+
+`devin-delegate` = general implement/review workhorse (browser/sandbox is a sub-capability).
+`kimi-delegate` = cheap small read-only. `grok-delegate` = **dormant** (revival gate: ≥5
+successful calls + a documented devin failure on a large repo).
+
+| Task type | Delegate | Command |
+|-----------|----------|---------|
+| General implementation / review / debug (workhorse) | `devin-delegate` | `devin-delegate --task "..." --workspace /path/to/repo` |
+| Browser, UI, screenshot, sandbox (a devin capability) | `devin-delegate` | `devin-delegate --task "..." --workspace /path/to/repo` |
+| Cheap **small read-only** search / summarize / draft / review | `kimi-delegate` | `kimi-delegate --task "..."` |
+| Local Codex write-mode implementation | `spark` | invoke via Codex write-mode |
+| Multi-file refactor on a very large codebase (DORMANT) | `grok-delegate` | `grok-delegate --task "..."` |
+| Unknown / orchestration | `devin-delegate` (workhorse); if clearly cheap+small, `kimi-delegate` | `devin-delegate --task "scope: ..."` |
+
+### Rules
+
+- **Never call delegates directly** (`opencode`, `pi --provider kimi-coding`, `devin`) — always use the wrapper scripts. Wrappers inject the envelope, fallback chain, and telemetry.
+- **Always include scope** in the task prompt: goal, constraints, acceptance checks, expected output format.
+- **Auth errors exit 126** — do not auto-retry. Print resume steps for the user.
+<!-- delegate-skill:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE — delegate routing
+
+<!-- delegate-skill:begin -->
+## AI Delegation Routing
+
+Route bounded tasks to the right AI delegate. Never call delegates directly —
+always use the wrapper binaries (envelope, fallback, telemetry).
+
+`devin-delegate` = general implement/review workhorse (browser/sandbox is a sub-capability).
+`kimi-delegate` = cheap small read-only. `grok-delegate` = **dormant** (revival gate: ≥5
+successful calls + a documented devin failure on a large repo).
+
+| Task | Delegate | Quick command |
+|------|----------|---------------|
+| General implement / review / debug (workhorse) | `devin-delegate` | `devin-delegate --task "..."` |
+| Browser / UI / screenshot / sandbox (a devin capability) | `devin-delegate` | `devin-delegate --task "..."` |
+| Cheap **small read-only** research / review / summarize | `kimi-delegate` | `kimi-delegate --task "..."` |
+| Local Codex write-mode impl | `/spark` | invoke `/spark` skill |
+| Multi-file refactor / very large codebase (DORMANT) | `grok-delegate` | `grok-delegate --task "..."` |
+| Unknown scope | `devin-delegate` (workhorse); if cheap+small, `kimi-delegate` | — |
+
+**Auth errors exit 126** — do not auto-retry; print resume steps. Canonical routing table
++ fallback/auth/latency notes: `~/.claude/skills/delegate-skill/SKILL.md`.
+<!-- delegate-skill:end -->


### PR DESCRIPTION
## Summary
- Adds the `delegate-skill` AI delegation routing block to `CLAUDE.md` (new) and `AGENTS.md` so Claude Code and Codex/non-Claude agents route bounded tasks to the right delegate.
- Routing model: `devin-delegate` = general implement/review workhorse, `kimi-delegate` = cheap small read-only, `grok-delegate` = dormant.
- Skill is symlinked under `.claude/skills/delegate-skill` (gitignored, local).

## Test plan
- [x] Block present exactly once in each file; canonical pointer to `~/.claude/skills/delegate-skill/SKILL.md`.
- [ ] Confirm agents pick up routing on next session.

Co-authored-by: Chimera <chimera_defi@protonmail.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)